### PR TITLE
Update jquery.slickgrid.export.excel.js

### DIFF
--- a/dist/jquery.slickgrid.export.excel.js
+++ b/dist/jquery.slickgrid.export.excel.js
@@ -53,7 +53,7 @@
             	}
 
             	//if cell style is defined by the user, then use that styles
-            	if (options.cellStyles)
+            	if (options.cellStyle)
             		styles["cellstyles"] = stylesheet.createFormat(options.cellStyle);
 
             		//else use default styles


### PR DESCRIPTION
I found a minor bug that was preventing me from using custom cell styles as described in the options.